### PR TITLE
`Pipe Plugins`: Include shebang

### DIFF
--- a/documentation/Command-summary.md
+++ b/documentation/Command-summary.md
@@ -415,6 +415,8 @@ A script intended for use by `--pipe` should expect a json array via stdin where
 Here is a simple example of a python script that reverses the order of items in a dataset:
 
 ```python3
+#!/usr/bin/env python
+
 import json
 import sys
 


### PR DESCRIPTION
Unless I'm missing something, I had to include a shebang in order to use a python script as custom plugin