### PR TITLE
Remove `ldb add-storage status`

### DIFF
--- a/documentation/Quick-start-teams.md
+++ b/documentation/Quick-start-teams.md
@@ -29,7 +29,6 @@ You can add new storage locations to LDB at any time, but you cannot remove stor
 | Step | Command |
 | --- | --- |
 | Add a new storage location | ` $  ldb add-storage gs://my-awesome-bucket/` |
-| Verify current LDB storage locations | `$  ldb add-storage status` |
 
 ### Registering a "read-add" storage location
 


### PR DESCRIPTION
Running this command  will add a new `add-storage` location in `{pwd}/status`.

Should `ldb status` accept `add-storage` as an argument?